### PR TITLE
Allow Method Overrides

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var passportLocalMongoose = require('passport-local-mongoose');
 var levelStore = require('level-session-store');
 var session = require('express-session');
 var cookieParser = require('cookie-parser');
+var methodOverrides = require('maki-forms');
 
 var flash = require('connect-flash');
 var async = require('async');
@@ -55,10 +56,12 @@ function PassportLocal( config ) {
         setup: function( maki ) {
           maki.passport = passport;
 
+          var LevelStore = levelStore( session );
+
           if (!fs.existsSync(process.env.PWD + '/data')) fs.mkdirSync(process.env.PWD + '/data');
           if (!fs.existsSync(process.env.PWD + '/data/sessions')) fs.mkdirSync(process.env.PWD + '/data/sessions');
 
-          var LevelStore = levelStore( session );
+          maki.app.use( methodOverrides );
           maki.app.use( cookieParser( maki.config.sessions.secret ) );
 
           maki.app.use( session({

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "express-session": "^1.10.2",
     "level": "^1.3.0",
     "level-session-store": "^2.0.1",
+    "maki-forms": "0.0.1",
     "passport": "^0.2.1",
     "passport-local": "^1.0.0",
     "passport-local-mongoose": "^1.0.0"


### PR DESCRIPTION
Since it cannot be known what order Maki plugins are used in, we now require the `maki-forms` module directly within this plugin.
